### PR TITLE
cheri-riscv: Fix handling of stval2 for MMU exceptions.

### DIFF
--- a/target/riscv/cpu_helper.c
+++ b/target/riscv/cpu_helper.c
@@ -1638,7 +1638,7 @@ void riscv_cpu_do_interrupt(CPUState *cs)
         riscv_log_instr_csr_changed(env, CSR_HTVAL);
 
 #ifdef TARGET_CHERI
-        if (cause == RISCV_EXCP_CHERI) {
+        if (cause == RISCV_EXCP_CHERI || write_tval) {
             env->stval2 = mtval2;
             riscv_log_instr_csr_changed(env, CSR_STVAL2);
         }


### PR DESCRIPTION
Update the value of stval2 correctly when a CHERI fault occurs as a result of PTE bits.

It appears that the value of stval2 is not set when MMU faults occur as a result of the PTE_CW or PTE_CRG bits.