### PR TITLE
cheri,riscv/virt: Use opensbi fw name not bbl

### DIFF
--- a/hw/riscv/virt.c
+++ b/hw/riscv/virt.c
@@ -888,8 +888,8 @@ static void virt_machine_init(MachineState *machine)
         firmware_end_addr = riscv_find_and_load_firmware(
             machine,
 #if defined(TARGET_CHERI)
-            /* Use a purecap BBL as the BIOS for CHERI. */
-            "bbl-riscv32cheri-virt-fw_jump.bin",
+            /* Use a purecap opensbi as the BIOS for CHERI. */
+            "opensbi-riscv32cheri-virt-fw_jump.bin",
 #else
             RISCV32_BIOS_BIN,
 #endif
@@ -898,8 +898,8 @@ static void virt_machine_init(MachineState *machine)
         firmware_end_addr = riscv_find_and_load_firmware(
             machine,
 #if defined(TARGET_CHERI)
-            /* Use a purecap BBL as the BIOS for CHERI. */
-            "bbl-riscv64cheri-virt-fw_jump.bin",
+            /* Use a purecap opensbi as the BIOS for CHERI. */
+            "opensbi-riscv64cheri-virt-fw_jump.bin",
 #else
             RISCV64_BIOS_BIN,
 #endif


### PR DESCRIPTION
BBL is not used and this is a wrong name for OpenSBI that we only use.