### PR TITLE
cheri_compressed_cap_128r: allow setting cap mode on X-less caps

### DIFF
--- a/target/cheri-common/cheri-compressed-cap/cheri_compressed_cap_128r.h
+++ b/target/cheri-common/cheri-compressed-cap/cheri_compressed_cap_128r.h
@@ -233,7 +233,7 @@ static inline _cc_mode _cc_N(get_execution_mode)(const _cc_cap_t* cap) {
 
 static inline bool _cc_N(set_execution_mode)(_cc_cap_t* cap, _cc_mode new_mode) {
     // While mode could always be set, the spec requires execute permission.
-    if (!_cc_N(has_permissions)(cap, _CC_N(PERM_EXECUTE)))
+    if (!_cc_N(has_permissions)(cap, _CC_N(PERM_EXECUTE)) && new_mode != _CC_N(MODE_CAP))
         return false;
     cap->cr_pesbt = _CC_DEPOSIT_FIELD(cap->cr_pesbt, (unsigned)new_mode, MODE);
     return true;


### PR DESCRIPTION
The specification allows capabilities without X-permission to have their M-bit set to (CHERI) Capability Mode.

Consider the following code:

```c
#include <cheriintrin.h>
#include <stdbool.h>
#include <stdio.h>
#include <sys/mman.h>

static void *riscv_cheri_build_cap(void *auth_cap, void *template_cap) {
	void *res;
	asm ("cbld %0, %1, %2"
		 : "=C" (res)
		 : "C" (auth_cap), "C" (template_cap)
		);
	return res;
}

static void *riscv_cheri_set_capmode(void *cap, int mode) {
	void *res;
	asm ("scmode %0, %1, %2"
		 : "=C" (res)
		 : "C" (cap), "r" (mode)
		);
	return res;
}

static unsigned long riscv_cheri_get_cap_mode(void* cap) {
	unsigned long res;
	asm ("gcmode %0, %1"
		 : "=r" (res)
		 : "C" (cap)
		);
	return res;
}
int main(int argc, char *argv[]) {
	void *rx_m0;
	bool qemu_trace = argc > 1;
	int i = 42; /* what else? */
	int *i_ptr = &i;

	rx_m0 = mmap(NULL, 4096, PROT_READ | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
	if (rx_m0 == MAP_FAILED) {
		perror("mmap() failed");
		return 1;
	}

	if (qemu_trace) asm volatile("slti zero, zero, 0x1b");
	void *rx_m1     = riscv_cheri_set_capmode(rx_m0, 1);
	void *r__m0     = cheri_perms_and(rx_m0, ~CHERI_PERM_EXECUTE);
	void *r__m1     = cheri_perms_and(rx_m1, ~CHERI_PERM_EXECUTE);
	void *r__m0_inv = riscv_cheri_build_cap(i_ptr, r__m0); /* tag clearing */
	if (qemu_trace) asm volatile("slti zero, zero, 0x1e");

	printf("rx_m0     = %#p [M=%lu]\n", rx_m0, riscv_cheri_get_cap_mode(rx_m0));
	printf("rx_m1     = %#p [M=%lu]\n", rx_m1, riscv_cheri_get_cap_mode(rx_m1));
	printf("r__m0     = %#p [M=%lu]\n", r__m0, riscv_cheri_get_cap_mode(r__m0));
	printf("r__m1     = %#p [M=%lu]\n", r__m1, riscv_cheri_get_cap_mode(r__m1));
	printf("r__m0_inv = %#p [M=%lu]\n", r__m0_inv, riscv_cheri_get_cap_mode(r__m0_inv));

	if (qemu_trace) asm volatile("slti zero, zero, 0x1b");
	void *res_cbld_r__m0_and_r__m0_inv = riscv_cheri_build_cap(r__m0, r__m0_inv);
	void *res_cbld_r__m1_and_r__m0_inv = riscv_cheri_build_cap(r__m1, r__m0_inv);
	if (qemu_trace) asm volatile("slti zero, zero, 0x1e");

	printf("res_cbld_r__m0_and_r__m0_inv = %#p\n", res_cbld_r__m0_and_r__m0_inv);
	printf("res_cbld_r__m1_and_r__m0_inv = %#p\n", res_cbld_r__m1_and_r__m0_inv);

	int res = 0;
	if (!cheri_tag_get(res_cbld_r__m0_and_r__m0_inv)) {
		fprintf(stderr, "ERROR: Tag NOT SET on res_cbld_r__m0_and_r__m0_inv when it should be\n");
		res = 1;
	}
	if (!cheri_tag_get(res_cbld_r__m1_and_r__m0_inv)) {
		fprintf(stderr, "ERROR: Tag NOT SET on res_cbld_r__m1_and_r__m0_inv when it should be\n");
		res = 1;
	}

	return res;
}
```

without this change, qemu would disallow setting `m=0` when invoking `cap_set_exec_mode()` in `helper_cbuildcap()` when the authorizing capability of `ybld` is `r__m1` (even though, technically this capability has set M=0).

Note that while I believe this change is "correct", I believe this is potentially a symptom of a larger issue: CHERI qemu seems to keep the M-bit set in `pesbt` and some helper functions to retrieve the M-bit value consider the X perm. Furthermore, it appears that `helper_candperm` does only reset ("fix") the M-bit for RVY32 if the X perm is set to 0. Shouldn't it do the same for RVY64?

On a related note: It seems to be the agreed upon behavior when trying to derive an X-less permission with M=0 is for
- `ypermc` to set the M-bit to zero, potentially creating a valid cap
- `cbld` to create an invalid cap (with M-bit and X perm set to one?)

Personally, this behavior is not obvious to me from reading the current CHERI spec. Maybe this should be explicitly spelled out?